### PR TITLE
Added reading passwords from file

### DIFF
--- a/unrarall
+++ b/unrarall
@@ -148,12 +148,38 @@ function isRarEncrypted()
 {
   case "$1" in
     unrar)
-      unrar l "$2" | grep -q -E "^\*"
-      RETCODE=$?
+      rar_listing=$(unrar l -p- "$2")
+      echo "${rar_listing}" | grep -q -E "^\*"
+      if [ "$?" -eq 0 ] ; then
+        # RAR file contains encrypted files
+        echo 1
+      else
+        echo "${rar_listing}" | grep -q -E "^Details: .+ encrypted headers"
+        if [ "$?" -eq 0 ] ; then
+          # RAR file is encrypted (even the file listing)
+          echo 1
+        else
+          # RAR file is not encrypted
+          echo 0
+        fi
+      fi
     ;;
     7z)
-      7z l -slt "$2" | grep -q -E "^Encrypted = \+$"
-      RETCODE=$?
+      rar_listing=$(7z l -slt -p- "$2")
+      echo "${rar_listing}" | grep -q -E "^Encrypted = \+$"
+      if [ "$?" -eq 0 ] ; then
+        # RAR file contains encrypted files
+        echo 1
+      else
+        echo "${rar_listing}" | grep -q -E "^Error: .+: Can not open encrypted archive\. Wrong password\?$"
+        if [ "$?" -eq 0 ] ; then
+          # RAR file is encrypted (even the file listing)
+          echo 1
+        else
+          # RAR file is not encrypted
+          echo 0
+        fi
+      fi
     ;;
     *)
       #This code should only be reached if the programmer has made an error
@@ -163,11 +189,6 @@ function isRarEncrypted()
       exit 1;
     ;;
   esac
-  if [ "$RETCODE" -eq 0 ]; then
-    echo "1"
-  else
-    echo "0"
-  fi
 }
 
 function detect-clean-up-hooks()


### PR DESCRIPTION
You can now create a password list (default is ~/.unrar_passwords), which is a simple text file containing archive passwords (separated by newlines). If an archive needs a password, then unrarall will read the file in a top down manner and try to use each password until it finds the correct one or reaches EOF.

Please note, that this commit removes the ability to get asked for a password and input it manually. IMHO this is not needed, as this tool is clearly designed for mass extraction and should not wait for user input (this is also why the '-y' option is used in the code). If you need to extract an archive with a password, just put it in the passwords file  and remove the file afterwards (or just use plain unrar/7z).

This fixes arfoll/unrarall#13.
