### PR TITLE
Group the message and exit commands, and instruct the user to install findutils

### DIFF
--- a/unrarall
+++ b/unrarall
@@ -494,7 +494,7 @@ while [ -n "$1" ]; do
 done
 
 if [[ $OSTYPE == darwin* ]]; then 
-    type -P gfind &>/dev/null && FIND=gfind || message error "Please install fileutils using HomeBrew. (http://brew.sh/)"; exit 1;
+    type -P gfind &>/dev/null && FIND=gfind || { message error "Please install findutils using HomeBrew. (http://brew.sh/)"; exit 1; }
 fi
 
 detect-clean-up-hooks


### PR DESCRIPTION
Grouping the commands stopped the script exiting even when it found gfile.

I also needed to brew install findutils rather than fileutils (which HomeBrew couldn't find, even after an update).