### PR TITLE
Allow tracking previously extracted files (and skipping subsequent extractions)

### DIFF
--- a/unrarall
+++ b/unrarall
@@ -27,6 +27,7 @@ declare -ix FORCE=0
 declare -ix VERBOSE=0
 declare -ix QUIET=0
 declare -ix CKSFV=1
+declare -ix TRACK_EXTRACTED=0
 declare -x UNRAR_METHOD="e"
 declare -x CKSFV_FLAGS="-q -g"
 declare -x UNRARALL_BIN="" #Leave empty to let unrarall to loop through UNRAR_BINARIES, setting this will disable searching through UNRAR_BINARIES
@@ -452,6 +453,9 @@ while [ -n "$1" ]; do
       -s | --disable-cksfv )
         CKSFV=0
       ;;
+      --track-extracted )
+        TRACK_EXTRACTED=1
+      ;;
       --clean=*)
         index=0;
         for hook in $( echo "$1" | sed 's/--clean=//' | tr , " ") ; do
@@ -646,6 +650,17 @@ for file in $(${FIND} "$DIR" -depth -iregex '.*\.\(rar\|001\)$'); do
     fi
   fi
 
+  TRACKED_FILE=1
+  if [ "$TRACK_EXTRACTED" -eq 1 ]; then
+    # check if this rar has been extracted already
+    if [ -e ".unrar" ]; then
+      size=$(wc -c <"${filename}")
+      grep -q "${sfilename}=${size}" ".unrar"
+      SUCCESS=$?
+      TRACKED_FILE=$SUCCESS
+    fi
+  fi
+
   # Compute fullpath to rar file
   filenameAbsolute="$(pwd)/${filename}"
 
@@ -659,7 +674,11 @@ for file in $(${FIND} "$DIR" -depth -iregex '.*\.\(rar\|001\)$'); do
   fi
 
   # unrar file if SFV checked out or --force was given
-  if [ "$SUCCESS" -eq 0 ] || [ "$FORCE" -eq 1 ]; then
+  SHOULD_EXTRACT=$SUCCESS
+  if [ "$SUCCESS" -eq 0 ] && [ "$TRACK_EXTRACTED" -eq 1 ] && [ "$TRACKED_FILE" -eq 0 ]; then
+      SHOULD_EXTRACT=1
+  fi
+  if [ "$SHOULD_EXTRACT" -eq 0 ] || [ "$FORCE" -eq 1 ]; then
     message nnl "Extracting (${UNRAR_METHOD}) \"$file\"..."
     file_encrypted=$(isRarEncrypted ${UNRARALL_BIN} ${filenameAbsolute})
     if [ "${file_encrypted}" -eq 0 ]; then
@@ -695,13 +714,21 @@ for file in $(${FIND} "$DIR" -depth -iregex '.*\.\(rar\|001\)$'); do
     fi
   fi
   # if fail remove from count
-  if [ "$SUCCESS" -eq 0 ] && [ "$FORCE" -eq 0 ] ; then
+  if [ "$SUCCESS" -eq 0 ] && [ "$TRACK_EXTRACTED" -eq 1 ] && [ "$TRACKED_FILE" -eq 0 ]; then
+      message ok "Already extracted (skipped)";
+  elif [ "$SUCCESS" -eq 0 ] && [ "$FORCE" -eq 0 ] ; then
     message ok "ok";
   elif [ "$SUCCESS" -eq 0 ] && [ "$FORCE" -eq 1 ] ; then
     message ok "ok (forced)";
   else
     let COUNT=COUNT-1
     [ "$FORCE" -eq 0 ] && message error "failed" || message error "failed (forced)"
+  fi
+ 
+  if [ "$SUCCESS" -eq 0 ] && [ "$TRACK_EXTRACTED" -eq 1 ] && [ "$TRACKED_FILE" -eq 1 ] ; then
+    # save the successful extraction
+     size=$(wc -c <"${filename}")
+     echo "${sfilename}=${size}" >> ".unrar"
   fi
 
   #Perform clean up if necessary


### PR DESCRIPTION
I'm not convinced my implementation is the best way to do this, but I didn't see any way to check if the file inside a rar was already extracted with the unrar tool. This seems hard to check for as well with multipart archives. 

I decided check for an existing .unrar file which this script creates... which is not ideal (polluting filesystems with dotfiles is a pet peeve of mine). I considered just keeping one file with a list of all the rar archives in the script location, but that's less portable (if you copy/move directories, that will think the file is no longer extracted. At least with dotfiles, they will move with any directory rename).

Thoughts? Suggestions? I'm certain this could be improved.
