### PR TITLE
Fix #38

### DIFF
--- a/tests/clean_up_hooks/rar_hook_volumes_legacy_spaces_in_file_name.test
+++ b/tests/clean_up_hooks/rar_hook_volumes_legacy_spaces_in_file_name.test
@@ -1,0 +1,27 @@
+# REQUIRES: rar_binary
+# Remove old temporary working directory
+# RUN: rm -rf %t
+# RUN: mkdir -p %t
+# RUN: cd %t
+
+# Make a simple test file.
+# State block size in bytes because *BSD dd doesn't support `M` suffix.
+# RUN: dd if=/dev/zero of="`pwd`/data file" count=2 bs=1048576
+# RUN: test -f "data file"
+
+# Make the rar volumes.
+# NOTE: We use no compression here because the data is all zeros
+# which compresses really well and would result in no volumes being
+# produced.
+# RUN: %rar a -m0 -vn -v512k "test thing.rar" "data file"
+# RUN: test -f "test thing.rar"
+# RUN: test -f "test thing.r00"
+# RUN: test -f "test thing.r01"
+# RUN: test -f "test thing.r02"
+# RUN: test -f "test thing.r03"
+# RUN: rm -f "data file"
+
+# Check the test file is extracted and rar files are removed
+# RUN: %unrarall --clean=rar .
+# RUN: test -f "data file"
+# RUN: test "$((%find . -type f -iname '*.r??' || echo '1') | wc -l)" -eq 0

--- a/tests/clean_up_hooks/rar_hook_volumes_part_spaces_in_file_name.test
+++ b/tests/clean_up_hooks/rar_hook_volumes_part_spaces_in_file_name.test
@@ -1,0 +1,26 @@
+# REQUIRES: rar_binary
+# Remove old temporary working directory
+# RUN: rm -rf %t
+# RUN: mkdir -p %t
+# RUN: cd %t
+
+# Make a simple test file.
+# State block size in bytes because *BSD dd doesn't support `M` suffix.
+# RUN: dd if=/dev/zero of="`pwd`/data file" count=2 bs=1048576
+# RUN: test -f "data file"
+
+# Make the rar volumes.
+# NOTE: We use no compression here because the data is all zeros
+# which compresses really well and would result in no volumes being
+# produced.
+# RUN: %rar a -m0 -v512k "test thing.rar" "data file"
+# RUN: test -f "test thing.part"*1.rar
+# RUN: test -f "test thing.part"*2.rar
+# RUN: test -f "test thing.part"*3.rar
+# RUN: test -f "test thing.part"*4.rar
+# RUN: rm -f "data file"
+
+# Check the test file is extracted and rar files are removed
+# RUN: %unrarall --clean=rar .
+# RUN: test -f "data file"
+# RUN: test "$((%find . -type f -iname '*.rar' || echo '1') | wc -l)" -eq 0

--- a/tests/feature/basic_with_spaces_in_dir.test
+++ b/tests/feature/basic_with_spaces_in_dir.test
@@ -1,0 +1,16 @@
+# REQUIRES: rar_binary
+# Remove old temporary working directory
+# RUN: rm -rf "%t SPACES"
+# RUN: mkdir -p "%t SPACES"
+# RUN: cd "%t SPACES"
+
+# Make a simple test file and put it in a simple rar file
+# RUN: echo "Test file" > test_file
+# RUN: %rar a test.rar test_file
+# RUN: test -f test.rar
+# RUN: rm test_file
+
+# Check the test file is extracted and rar file is removed
+# RUN: %unrarall --clean=rar .
+# RUN: test -f test_file
+# RUN: test ! -f test.rar

--- a/tests/feature/basic_with_spaces_in_rar_file_name.test
+++ b/tests/feature/basic_with_spaces_in_rar_file_name.test
@@ -1,0 +1,16 @@
+# REQUIRES: rar_binary
+# Remove old temporary working directory
+# RUN: rm -rf %t
+# RUN: mkdir -p %t
+# RUN: cd %t
+
+# Make a simple test file and put it in a simple rar file
+# RUN: echo "Test file" > "test file"
+# RUN: %rar a "test thing.rar" "test file"
+# RUN: test -f "test thing.rar"
+# RUN: rm "test file"
+
+# Check the test file is extracted and rar file is removed
+# RUN: %unrarall --clean=rar .
+# RUN: test -f "test file"
+# RUN: test ! -f "test thing.rar"

--- a/tests/travisci_install.sh
+++ b/tests/travisci_install.sh
@@ -7,9 +7,7 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
 
   # Install unrar, rar and 7z.
   brew install p7zip
-  # FIXME: This will likely break in the future.
-  # See: https://github.com/caskroom/homebrew-cask/issues/28611
-  brew install Homebrew/homebrew-binary/rar
+  brew cask install rar
 
   # Install python
   brew install python3

--- a/unrarall
+++ b/unrarall
@@ -770,7 +770,7 @@ for file in $(find_wrapper "$DIR" -depth -iregex '.*\.(rar|001)$'); do
     if [ "${file_encrypted}" -eq 0 ]; then
       # The file is not encrypted. We're extracting without a password
       # Use eval so that redirection gets evaluated correctly
-      eval ${UNRARALL_BIN} ${UNRAR_METHOD} $( getUnrarFlags ${UNRARALL_BIN}) -p- "$filenameAbsolute" \
+      eval ${UNRARALL_BIN} ${UNRAR_METHOD} $( getUnrarFlags ${UNRARALL_BIN}) -p- "\"${filenameAbsolute}\"" \
         $([ "$VERBOSE" -eq 0 -a "X${UNRARALL_BIN}" != "Xecho" ] && echo ">/dev/null")
       SUCCESS=$?
     else
@@ -779,7 +779,7 @@ for file in $(find_wrapper "$DIR" -depth -iregex '.*\.(rar|001)$'); do
         [ $VERBOSE -eq 1 ] && message info "This archive is encrypted. Trying passwords from password file \"${UNRARALL_PASSWORD_FILE}\"..."
         while true; do read password || break
           # Use eval so that redirection gets evaluated correctly
-          eval ${UNRARALL_BIN} ${UNRAR_METHOD} $( getUnrarFlags ${UNRARALL_BIN}) -p"$password" "$filenameAbsolute" \
+          eval ${UNRARALL_BIN} ${UNRAR_METHOD} $( getUnrarFlags ${UNRARALL_BIN}) -p"\"$password\"" "\"${filenameAbsolute}\"" \
             $([ "$VERBOSE" -eq 0 -a "X${UNRARALL_BIN}" != "Xecho" ] && echo ">/dev/null")
           SUCCESS=$?
           if [ "$SUCCESS" -eq 0 ] ; then


### PR DESCRIPTION
d1188a095fbb04a556852d253b9d6d0039202444 introduced use of `eval`
which broken the quoted file paths. Try fix by adding extra quotes.