### PR TITLE
Don't clobber files on extraction and skip already extracted files

### DIFF
--- a/tests/command_line/1
+++ b/tests/command_line/1
@@ -1,1 +1,0 @@
-grep: 2: No such file or directory

--- a/tests/command_line/1
+++ b/tests/command_line/1
@@ -1,0 +1,1 @@
+grep: 2: No such file or directory

--- a/tests/feature/multipart.test
+++ b/tests/feature/multipart.test
@@ -1,0 +1,20 @@
+# REQUIRES: rar_binary
+# Remove old temporary working directory
+# RUN: rm -rf %t
+# RUN: mkdir -p %t
+# RUN: cd %t
+
+# Make a 10MB file and put it in a 3.5M rar multipart archives
+# RUN: dd if=/dev/urandom of=test.img bs=1024k count=10 iflag=fullblock
+# RUN: %rar a -v3500k test.rar test.img
+# RUN: test -f test.part1.rar
+# RUN: test -f test.part2.rar
+# RUN: test -f test.part3.rar
+# RUN: rm test.img
+
+# Check the test file is extracted and rar file is removed
+# RUN: %unrarall --clean=rar .
+# RUN: test -f test.img
+# RUN: test ! -f test.part1.rar
+# RUN: test ! -f test.part2.rar
+# RUN: test ! -f test.part3.rar

--- a/tests/feature/multipart.test
+++ b/tests/feature/multipart.test
@@ -5,7 +5,7 @@
 # RUN: cd %t
 
 # Make a 10MB file and put it in a 3.5M rar multipart archives
-# RUN: dd if=/dev/urandom of=test.img bs=1024k count=10 iflag=fullblock
+# RUN: dd if=/dev/urandom of=test.img bs=1024k count=10
 # RUN: %rar a -v3500k test.rar test.img
 # RUN: test -f test.part1.rar
 # RUN: test -f test.part2.rar

--- a/tests/feature/recursive.test
+++ b/tests/feature/recursive.test
@@ -1,0 +1,28 @@
+# REQUIRES: rar_binary
+# Remove old temporary working directory
+# RUN: rm -rf %t
+# RUN: mkdir -p %t
+# RUN: cd %t
+
+# Make a simple test file and put it in a simple rar file
+# RUN: echo "Test file" > test_file
+# RUN: %rar a test.rar test_file
+# RUN: test -f test.rar
+# RUN: rm test_file
+
+# Make make a second rar file containing the first rar file
+# RUN: %rar a second_archive.rar test.rar
+# RUN: test -f second_archive.rar
+# RUN: rm test.rar
+
+# Make make a third rar file containing the second rar file
+# RUN: %rar a third_archive.rar second_archive.rar
+# RUN: test -f third_archive.rar
+# RUN: rm second_archive.rar
+
+# Check the test file is extracted and rar file is removed
+# RUN: %unrarall --clean=rar .
+# RUN: test -f test_file
+# RUN: test ! -f test.rar
+# RUN: test ! -f second_archive.rar
+# RUN: test ! -f third_archive.rar

--- a/tests/feature/recursive_no_depth.test
+++ b/tests/feature/recursive_no_depth.test
@@ -1,0 +1,28 @@
+# REQUIRES: rar_binary
+# Remove old temporary working directory
+# RUN: rm -rf %t
+# RUN: mkdir -p %t
+# RUN: cd %t
+
+# Make a simple test file and put it in a simple rar file
+# RUN: echo "Test file" > test_file
+# RUN: %rar a test.rar test_file
+# RUN: test -f test.rar
+# RUN: rm test_file
+
+# Make make a second rar file containing the first rar file
+# RUN: %rar a second_archive.rar test.rar
+# RUN: test -f second_archive.rar
+# RUN: rm test.rar
+
+# Make make a third rar file containing the second rar file
+# RUN: %rar a third_archive.rar second_archive.rar
+# RUN: test -f third_archive.rar
+# RUN: rm second_archive.rar
+
+# Check the test file is not extracted and the inner rar remains
+# RUN: %unrarall --depth 0 .
+# RUN: test ! -f test_file
+# RUN: test ! -f test.rar
+# RUN: test -f second_archive.rar
+# RUN: test -f third_archive.rar

--- a/tests/feature/skip_if_exists_7z.test
+++ b/tests/feature/skip_if_exists_7z.test
@@ -12,7 +12,7 @@
 # RUN: test -f test.rar
 
 # Check that unrarall returns a normal exit code if the files exist
-# RUN: %unrarall --backend=7z --skip-if-exists .
+# RUN: %unrarall --skip-if-exists .
 
 # Remove old temporary working directory
 # RUN: rm -rf %t
@@ -27,5 +27,5 @@
 # RUN: rm test_file
 
 # Check that unrarall returns a normal exit code
-# RUN: %unrarall --backend=7z --skip-if-exists .
+# RUN: %unrarall --skip-if-exists .
 # RUN: test -f test_file

--- a/tests/feature/skip_if_exists_7z.test
+++ b/tests/feature/skip_if_exists_7z.test
@@ -1,0 +1,31 @@
+# REQUIRES: rar_binary
+# REQUIRES: 7z_backend
+# Remove old temporary working directory
+# RUN: rm -rf %t
+# RUN: mkdir -p %t
+# RUN: cd %t
+
+# Make a set of test files and put it in a rar archive
+# RUN: echo "Test file" > test_file
+# RUN: echo "Whitespace test file" > "whitespace file"
+# RUN: %rar a test.rar test_file "whitespace file"
+# RUN: test -f test.rar
+
+# Check that unrarall returns a normal exit code if the files exist
+# RUN: %unrarall --backend=7z --skip-if-exists .
+
+# Remove old temporary working directory
+# RUN: rm -rf %t
+# RUN: mkdir -p %t
+# RUN: cd %t
+
+# Make a set of test files and put it in a rar archive, remove one file
+# RUN: echo "Test file" > test_file
+# RUN: echo "Whitespace test file" > "whitespace file"
+# RUN: %rar a test.rar test_file "whitespace file"
+# RUN: test -f test.rar
+# RUN: rm test_file
+
+# Check that unrarall returns a normal exit code
+# RUN: %unrarall --backend=7z --skip-if-exists .
+# RUN: test -f test_file

--- a/tests/feature/skip_if_exists_multipart.test
+++ b/tests/feature/skip_if_exists_multipart.test
@@ -6,7 +6,7 @@
 # RUN: cd %t
 
 # Make a 10MB file and put it in a 3.5M rar multipart archives
-# RUN: dd if=/dev/urandom of=test.img bs=1M count=10 iflag=fullblock
+# RUN: dd if=/dev/urandom of=test.img bs=1024k count=10
 # RUN: %rar a -v3500k test.rar test.img
 # RUN: test -f test.part1.rar
 # RUN: test -f test.part2.rar
@@ -16,4 +16,4 @@
 
 # Check the test file is not extracted
 # RUN: %unrarall --skip-if-exists .
-# RUN: grep "test data" test.img 
+# RUN: grep "test data" test.img

--- a/tests/feature/skip_if_exists_multipart.test
+++ b/tests/feature/skip_if_exists_multipart.test
@@ -1,0 +1,19 @@
+# REQUIRES: rar_binary
+# REQUIRES: rar_backend
+# Remove old temporary working directory
+# RUN: rm -rf %t
+# RUN: mkdir -p %t
+# RUN: cd %t
+
+# Make a 10MB file and put it in a 3.5M rar multipart archives
+# RUN: dd if=/dev/urandom of=test.img bs=1M count=10 iflag=fullblock
+# RUN: %rar a -v3500k test.rar test.img
+# RUN: test -f test.part1.rar
+# RUN: test -f test.part2.rar
+# RUN: test -f test.part3.rar
+# RUN: rm test.img
+# RUN: echo "test data" > test.img
+
+# Check the test file is not extracted
+# RUN: %unrarall --skip-if-exists .
+# RUN: grep "test data" test.img 

--- a/tests/feature/skip_if_exists_rar.test
+++ b/tests/feature/skip_if_exists_rar.test
@@ -12,7 +12,7 @@
 # RUN: test -f test.rar
 
 # Check that unrarall returns a normal exit code if the files exist
-# RUN: %unrarall --backend=rar --skip-if-exists .
+# RUN: %unrarall --skip-if-exists .
 
 # Remove old temporary working directory
 # RUN: rm -rf %t
@@ -27,5 +27,5 @@
 # RUN: rm test_file
 
 # Check that unrarall returns a normal exit code
-# RUN: %unrarall --backend=rar --skip-if-exists .
+# RUN: %unrarall --skip-if-exists .
 # RUN: test -f test_file

--- a/tests/feature/skip_if_exists_rar.test
+++ b/tests/feature/skip_if_exists_rar.test
@@ -1,0 +1,31 @@
+# REQUIRES: rar_binary
+# REQUIRES: rar_backend
+# Remove old temporary working directory
+# RUN: rm -rf %t
+# RUN: mkdir -p %t
+# RUN: cd %t
+
+# Make a set of test files and put it in a rar archive
+# RUN: echo "Test file" > test_file
+# RUN: echo "Whitespace test file" > "whitespace file"
+# RUN: %rar a test.rar test_file "whitespace file"
+# RUN: test -f test.rar
+
+# Check that unrarall returns a normal exit code if the files exist
+# RUN: %unrarall --backend=rar --skip-if-exists .
+
+# Remove old temporary working directory
+# RUN: rm -rf %t
+# RUN: mkdir -p %t
+# RUN: cd %t
+
+# Make a set of test files and put it in a rar archive, remove one file
+# RUN: echo "Test file" > test_file
+# RUN: echo "Whitespace test file" > "whitespace file"
+# RUN: %rar a test.rar test_file "whitespace file"
+# RUN: test -f test.rar
+# RUN: rm test_file
+
+# Check that unrarall returns a normal exit code
+# RUN: %unrarall --backend=rar --skip-if-exists .
+# RUN: test -f test_file

--- a/tests/feature/skip_if_exists_unrar.test
+++ b/tests/feature/skip_if_exists_unrar.test
@@ -1,0 +1,31 @@
+# REQUIRES: rar_binary
+# REQUIRES: unrar_backend
+# Remove old temporary working directory
+# RUN: rm -rf %t
+# RUN: mkdir -p %t
+# RUN: cd %t
+
+# Make a set of test files and put it in a rar archive
+# RUN: echo "Test file" > test_file
+# RUN: echo "Whitespace test file" > "whitespace file"
+# RUN: %rar a test.rar test_file "whitespace file"
+# RUN: test -f test.rar
+
+# Check that unrarall returns a normal exit code if the files exist
+# RUN: %unrarall --backend=unrar --skip-if-exists .
+
+# Remove old temporary working directory
+# RUN: rm -rf %t
+# RUN: mkdir -p %t
+# RUN: cd %t
+
+# Make a set of test files and put it in a rar archive, remove one file
+# RUN: echo "Test file" > test_file
+# RUN: echo "Whitespace test file" > "whitespace file"
+# RUN: %rar a test.rar test_file "whitespace file"
+# RUN: test -f test.rar
+# RUN: rm test_file
+
+# Check that unrarall returns a normal exit code
+# RUN: %unrarall --backend=unrar --skip-if-exists .
+# RUN: test -f test_file

--- a/tests/feature/skip_if_exists_unrar.test
+++ b/tests/feature/skip_if_exists_unrar.test
@@ -12,7 +12,7 @@
 # RUN: test -f test.rar
 
 # Check that unrarall returns a normal exit code if the files exist
-# RUN: %unrarall --backend=unrar --skip-if-exists .
+# RUN: %unrarall --skip-if-exists .
 
 # Remove old temporary working directory
 # RUN: rm -rf %t
@@ -27,5 +27,5 @@
 # RUN: rm test_file
 
 # Check that unrarall returns a normal exit code
-# RUN: %unrarall --backend=unrar --skip-if-exists .
+# RUN: %unrarall --skip-if-exists .
 # RUN: test -f test_file

--- a/unrarall
+++ b/unrarall
@@ -438,6 +438,7 @@ function unrarall_clean_empty_folders()
     ;;
   esac
 }
+#end of clean-up hooks
 
 function safe_move()
 {
@@ -452,8 +453,6 @@ function safe_move()
     done
   fi
 }
-
-#end of clean-up hooks
 
 # Detect the version of sed available and create a wrapper function
 # that will behave like sed using "extended regular expressions"
@@ -479,8 +478,17 @@ if [ "$#" -lt 1 ]; then
   exit 1;
 fi
 
+# Save a copy of the original cmd + args
+UNRARALL_CMD="${0}"
+
 while [ -n "$1" ]; do
   if [ $# -gt 1 ] || [ $( echo "$1" | grep -Ec '^(-h|--help|--version)$' ) -eq 1 ] ; then
+
+    # save all the args passed to the cmd, except for --depth
+    if [ "${1}" != "--depth" ]; then
+      UNRARALL_CMD="${UNRARALL_CMD} ${1}"
+    fi
+
     #Handle optional arguments
     case "$1" in
       -h | --help )
@@ -528,6 +536,7 @@ while [ -n "$1" ]; do
       ;;
       -o | --output)
         shift
+        UNRARALL_CMD="${UNRARALL_CMD} ${1}"
         UNRARALL_OUTPUT_DIR="$1"
         if [ ! -d "${UNRARALL_OUTPUT_DIR}" ]; then
           message error "\"${UNRARALL_OUTPUT_DIR}\" is not a directory"
@@ -555,6 +564,7 @@ while [ -n "$1" ]; do
       ;;
       --password-file)
         shift
+        UNRARALL_CMD="${UNRARALL_CMD} ${1}"
         if [ ! -e "$1" ]; then
           message error "\"$1\" does not exist."
           exit 1
@@ -591,6 +601,7 @@ while [ -n "$1" ]; do
       ;;
       --find-binary)
         shift
+        UNRARALL_CMD="${UNRARALL_CMD} ${1}"
         FIND="${1}"
       ;;
       *)
@@ -842,6 +853,13 @@ for file in $(find_wrapper "$DIR" -depth -iregex '.*\.(rar|001)$'); do
     let COUNT=COUNT-1
     let FAIL_COUNT=FAIL_COUNT+1
     [ "$FORCE" -eq 0 ] && message error "failed" || message error "failed (forced)"
+  fi
+
+  # Check if any recursive extraction is needed
+  if [ "${UNRARALL_DEPTH}" -gt 0 ] && [[ -n `find_wrapper . -depth -iregex '.*\.(rar|001)$'` ]]; then
+    [ $VERBOSE -eq 1 ] && message ok "Detected rar archives inside of \"$file\", recursively extracting"
+    let NEW_DEPTH=UNRARALL_DEPTH-1
+    eval $UNRARALL_CMD --depth $NEW_DEPTH ${tmp_dir}
   fi
 
   # Save the files extracted

--- a/unrarall
+++ b/unrarall
@@ -38,7 +38,7 @@ declare -x UNRARALL_PASSWORD_FILE="${HOME}/.unrar_passwords" #If this exists and
 declare -ax UNRARALL_DETECTED_CLEAN_UP_HOOKS
 declare -ax UNRARALL_CLEAN_UP_HOOKS_TO_RUN=(none)
 declare -x UNRARALL_OUTPUT_DIR=""
-declare -ix DEPTH=8
+declare -ix DEPTH=4
 declare -ix SKIP_IF_EXISTS=0
 declare -ix MV_BACKUP=0 # 0 -> we can use mv -b, 1 -> resort to shenanigans to not clobber when moving
 `mv --help | grep  "\-\-backup" 2>&1 >/dev/null`
@@ -90,7 +90,7 @@ OPTIONS
 -o, --output         Specify a directory to extract rar files. By default files
                      will be extracted in the directory containing the rar file.
 --depth              Maximum depth that nested rar files will be extracted. By
-                     default, is a depth of 8.
+                     default, is a depth of 4.
 --skip-if-exists     Skip extraction of archive if all files already exists.
                      Note: files are only checked by name, not by contents!
 --password-file      Specify path to password file.
@@ -512,7 +512,7 @@ if [ "$#" -lt 1 ]; then
 fi
 
 # Save a copy of the original cmd + args
-UNRARALL_CMD="${0}"
+UNRARALL_CMD="${BASH_SOURCE[0]}"
 
 while [ -n "$1" ]; do
   if [ $# -gt 1 ] || [ $( echo "$1" | grep -Ec '^(-h|--help|--version)$' ) -eq 1 ] ; then

--- a/unrarall
+++ b/unrarall
@@ -38,12 +38,13 @@ declare -x UNRARALL_PASSWORD_FILE="${HOME}/.unrar_passwords" #If this exists and
 declare -ax UNRARALL_DETECTED_CLEAN_UP_HOOKS
 declare -ax UNRARALL_CLEAN_UP_HOOKS_TO_RUN=(none)
 declare -x UNRARALL_OUTPUT_DIR=""
+declare -x UNRARALL_DEPTH=8
 
 function usage()
 {
   echo "Usage: ${UNRARALL_EXECUTABLE_NAME} [ --clean=<hook>[,<hook>] ] [ --force ] [ --full-path ]
                 [ --verbose | --quiet ] [--7zip | --backend=<backend> ] [--dry] [--disable-cksfv] [ --password-file <file> ]
-                [ --output DIRECTORY ] [ --find-binary <binary_path> ] <DIRECTORY>
+                [ --output DIRECTORY ] [ --find-binary <binary_path> ] [ --depth <amt> ] <DIRECTORY>
        ${UNRARALL_EXECUTABLE_NAME} --help
        ${UNRARALL_EXECUTABLE_NAME} --version
 
@@ -84,6 +85,8 @@ OPTIONS
                      screen
 -o, --output         Specify a directory to extract rar files. By default files
                      will be extracted in the directory containing the rar file.
+--depth              Maximum depth that nested rar files will be extracted. By
+                     default, is a depth of 8.
 --password-file      Specify path to password file.
                      Default \"${UNRARALL_PASSWORD_FILE}\".
 --backend            Force particular backend (unrar, rar, or 7z)
@@ -520,6 +523,19 @@ while [ -n "$1" ]; do
         # because we may be changing directory multiple times
         UNRARALL_OUTPUT_DIR="$(cd "${UNRARALL_OUTPUT_DIR}" ; pwd)"
       ;;
+      --depth)
+        shift
+        UNRARALL_DEPTH="$1"
+        case $UNRARALL_DEPTH in
+          ''|*[!0-9]*)
+            message error "\"${UNRARALL_DEPTH}\" is not a number"
+            exit 1
+           ;;
+          *)
+            message info "Using \"${UNRARALL_DEPTH}\" as as the maximum depth"
+          ;;
+        esac
+      ;;
       --password-file)
         shift
         if [ ! -e "$1" ]; then
@@ -754,14 +770,18 @@ for file in $(find_wrapper "$DIR" -depth -iregex '.*\.(rar|001)$'); do
   # Compute fullpath to rar file
   filenameAbsolute="$(pwd)/${filename}"
 
-  # If user specified extraction directory change to it now
-  if [ -n "${UNRARALL_OUTPUT_DIR}" ]; then
-    cd "${UNRARALL_OUTPUT_DIR}"
-    if [ $? -ne 0 ]; then
-      message error "Failed to switch to output directory \"${UNRARALL_OUTPUT_DIR}\""
-      exit 1
-    fi
+  # Switch to a temporary directory so the extracted file does not clobber anything
+  tmp_dir=`mktemp -d -p . 2>/dev/null`
+  if [ $? -ne 0 ] || [ -z ${tmp_dir} ] || [ ! -d "${tmp_dir}" ]; then
+    message error "Failed to create a temporary directory to handle extraction"
+    exit 1
   fi
+  cd "${tmp_dir}"
+  if [ $? -ne 0 ]; then
+    message error "Failed to switch to tmp directory \"${tmp_dir}\""
+    exit 1
+  fi
+  tmp_dir=`pwd`
 
   # unrar file if SFV checked out or --force was given
   if [ "$SUCCESS" -eq 0 ] || [ "$FORCE" -eq 1 ]; then
@@ -804,6 +824,48 @@ for file in $(find_wrapper "$DIR" -depth -iregex '.*\.(rar|001)$'); do
     let COUNT=COUNT-1
     let FAIL_COUNT=FAIL_COUNT+1
     [ "$FORCE" -eq 0 ] && message error "failed" || message error "failed (forced)"
+  fi
+
+  # Save the files extracted
+  files=( $(find_wrapper . -mindepth 1 -type f) )
+
+  # If user specified extraction directory change to it now
+  if [ -n "${UNRARALL_OUTPUT_DIR}" ]; then
+    cd "${UNRARALL_OUTPUT_DIR}"
+    if [ $? -ne 0 ]; then
+      message error "Failed to switch to output directory \"${UNRARALL_OUTPUT_DIR}\""
+      exit 1
+    fi
+  else
+    cd "${RARFILE_DIR}"
+    if [ $? -ne 0 ]; then
+      message error "Failed to switch to rar directory \"${RARFILE_DIR}\""
+      exit 1
+    fi
+  fi
+
+  # Move extracted files to cwd safely
+  for extracted_file in "${files[@]}"; do
+    mkdir -p "$(dirname ${extracted_file})"
+    if [ $? -ne 0 ]; then
+      message error "Unable to create directory structure for \"$(dirname ${extracted_file})\""
+      exit 1
+    fi
+    mv -b "${tmp_dir}/${extracted_file}" "${extracted_file}"
+    if [ $? -ne 0 ]; then
+      message error "Failed to move \"${extracted_file}\" to \"${RARFILE_DIR}\""
+      exit 1
+    fi
+  done
+
+  # Remove the tmp directory
+  if [ -d "${tmp_dir}" ]; then
+    find_wrapper "${tmp_dir}" -mindepth 1 -type d -empty -delete
+    rmdir "${tmp_dir}"
+    if [ $? -ne 0 ]; then
+      message error "Failed cleanup temporary directory \"${tmp_dir}\""
+      exit 1
+    fi
   fi
 
   #Perform clean up if necessary

--- a/unrarall
+++ b/unrarall
@@ -38,7 +38,10 @@ declare -x UNRARALL_PASSWORD_FILE="${HOME}/.unrar_passwords" #If this exists and
 declare -ax UNRARALL_DETECTED_CLEAN_UP_HOOKS
 declare -ax UNRARALL_CLEAN_UP_HOOKS_TO_RUN=(none)
 declare -x UNRARALL_OUTPUT_DIR=""
-declare -x UNRARALL_DEPTH=8
+declare -ix UNRARALL_DEPTH=8
+declare -ix MV_BACKUP=0 # 0 -> we can use mv -b, 1 -> resort to shenanigans to not clobber when moving
+`mv --help | grep  "\-\-backup" 2>&1 >/dev/null`
+MV_BACKUP=$?
 
 function usage()
 {
@@ -434,6 +437,20 @@ function unrarall_clean_empty_folders()
       message error "Could not execute empty_folders hook"
     ;;
   esac
+}
+
+function safe_move()
+{
+  if [ "$MV_BACKUP" -eq 0 ]; then
+    mv -b "${1}" "${2}"
+  else
+    mv -n "${1}" "${2}"
+    FILE_COUNT=1
+    while [ -e "${1}" ]; do
+      mv -n "${1}" "${2}.${FILE_COUNT}"
+      let FILE_COUNT=FILE_COUNT+1
+    done
+  fi
 }
 
 #end of clean-up hooks
@@ -854,7 +871,7 @@ for file in $(find_wrapper "$DIR" -depth -iregex '.*\.(rar|001)$'); do
       message error "Unable to create directory structure for \"$(dirname ${extracted_file})\""
       exit 1
     fi
-    mv -b "${tmp_dir}/${extracted_file}" "${extracted_file}"
+    safe_move "${tmp_dir}/${extracted_file}" "${extracted_file}"
     if [ $? -ne 0 ]; then
       message error "Failed to move \"${extracted_file}\" to \"${RARFILE_DIR}\""
       exit 1

--- a/unrarall
+++ b/unrarall
@@ -828,6 +828,8 @@ for file in $(find_wrapper "$DIR" -depth -iregex '.*\.(rar|001)$'); do
 
   # Save the files extracted
   files=( $(find_wrapper . -mindepth 1 -type f) )
+  # Save the empty directories extracted
+  empty_directories=( $(find_wrapper . -mindepth 1 -type d -empty) )
 
   # If user specified extraction directory change to it now
   if [ -n "${UNRARALL_OUTPUT_DIR}" ]; then
@@ -854,6 +856,13 @@ for file in $(find_wrapper "$DIR" -depth -iregex '.*\.(rar|001)$'); do
     mv -b "${tmp_dir}/${extracted_file}" "${extracted_file}"
     if [ $? -ne 0 ]; then
       message error "Failed to move \"${extracted_file}\" to \"${RARFILE_DIR}\""
+      exit 1
+    fi
+  done
+  for dir in "${empty_directories[@]}"; do
+    mkdir -p "${dir}"
+    if [ $? -ne 0 ]; then
+      message error "Unable to create directory structure for \"${dir}\""
       exit 1
     fi
   done

--- a/unrarall
+++ b/unrarall
@@ -512,7 +512,9 @@ if [ "$#" -lt 1 ]; then
 fi
 
 # Save a copy of the original cmd + args
-UNRARALL_CMD="${BASH_SOURCE[0]}"
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+SCRIPT_NAME=`basename "${BASH_SOURCE[0]}"`
+UNRARALL_CMD="$SCRIPT_DIR/$SCRIPT_NAME"
 
 while [ -n "$1" ]; do
   if [ $# -gt 1 ] || [ $( echo "$1" | grep -Ec '^(-h|--help|--version)$' ) -eq 1 ] ; then

--- a/unrarall
+++ b/unrarall
@@ -38,7 +38,8 @@ declare -x UNRARALL_PASSWORD_FILE="${HOME}/.unrar_passwords" #If this exists and
 declare -ax UNRARALL_DETECTED_CLEAN_UP_HOOKS
 declare -ax UNRARALL_CLEAN_UP_HOOKS_TO_RUN=(none)
 declare -x UNRARALL_OUTPUT_DIR=""
-declare -ix UNRARALL_DEPTH=8
+declare -ix DEPTH=8
+declare -ix SKIP_IF_EXISTS=0
 declare -ix MV_BACKUP=0 # 0 -> we can use mv -b, 1 -> resort to shenanigans to not clobber when moving
 `mv --help | grep  "\-\-backup" 2>&1 >/dev/null`
 MV_BACKUP=$?
@@ -47,7 +48,7 @@ function usage()
 {
   echo "Usage: ${UNRARALL_EXECUTABLE_NAME} [ --clean=<hook>[,<hook>] ] [ --force ] [ --full-path ]
                 [ --verbose | --quiet ] [--7zip | --backend=<backend> ] [--dry] [--disable-cksfv] [ --password-file <file> ]
-                [ --output DIRECTORY ] [ --find-binary <binary_path> ] [ --depth <amt> ] <DIRECTORY>
+                [ --output DIRECTORY ] [ --find-binary <binary_path> ] [ --depth <amt> ] [--skip-if-exists] <DIRECTORY>
        ${UNRARALL_EXECUTABLE_NAME} --help
        ${UNRARALL_EXECUTABLE_NAME} --version
 
@@ -90,6 +91,8 @@ OPTIONS
                      will be extracted in the directory containing the rar file.
 --depth              Maximum depth that nested rar files will be extracted. By
                      default, is a depth of 8.
+--skip-if-exists     Skip extraction of archive if all files already exists.
+                     Note: files are only checked by name, not by matching contents
 --password-file      Specify path to password file.
                      Default \"${UNRARALL_PASSWORD_FILE}\".
 --backend            Force particular backend (unrar, rar, or 7z)
@@ -174,6 +177,36 @@ function getUnrarFlags()
       exit 1;
     ;;
   esac
+}
+
+#function to check if an archive has been extracted already
+function isAlreadyExtracted()
+{
+  case "$1" in
+    unrar)
+      file_listing_cmd="unrar lb \"$2\""
+    ;;
+    7z)
+      file_listing_cmd="7z l \"$2\" | sed -n -e '/-------------------/,/-------------------/ p' | sed '1d;\$d' | awk '{out=\$6; for(i=7;i<=NF;i++){out=out\" \"\$i}; print out}'"
+    ;;
+    rar)
+      file_listing_cmd="rar lb \"$2\""
+    ;;
+    echo)
+      return 1
+    ;;
+    *)
+      message info "Unable to determine if \"$2\" was already extracted with \"$1\"."
+      message info "Assuming \"$2\" has never been extracted."
+      return 1
+    ;;
+  esac
+  for rar_file in $(eval $file_listing_cmd); do
+    if [ ! -e $rar_file ]; then
+      return 1
+    fi
+  done
+  return 0
 }
 
 #function to check if file is password protected
@@ -551,16 +584,19 @@ while [ -n "$1" ]; do
       ;;
       --depth)
         shift
-        UNRARALL_DEPTH="$1"
-        case $UNRARALL_DEPTH in
+        DEPTH="$1"
+        case $DEPTH in
           ''|*[!0-9]*)
-            message error "\"${UNRARALL_DEPTH}\" is not a number"
+            message error "\"${DEPTH}\" is not a number"
             exit 1
            ;;
           *)
-            message info "Using \"${UNRARALL_DEPTH}\" as as the maximum depth"
+            message info "Using \"${DEPTH}\" as as the maximum depth"
           ;;
         esac
+      ;;
+      --skip-if-exists)
+        SKIP_IF_EXISTS=1
       ;;
       --password-file)
         shift
@@ -798,6 +834,15 @@ for file in $(find_wrapper "$DIR" -depth -iregex '.*\.(rar|001)$'); do
   # Compute fullpath to rar file
   filenameAbsolute="$(pwd)/${filename}"
 
+  # Check if file is extracted
+  if [ "$SKIP_IF_EXISTS" -eq 1 ] && [ "$SUCCESS" -eq 0 ] && [ "$FORCE" -eq 0 ]; then
+    isAlreadyExtracted ${UNRARALL_BIN} ${filenameAbsolute}
+    if [ "$?" -eq 0 ]; then
+      message ok "File \"${filenameAbsolute}\" appears to have already been extracted, skipping..."
+      continue
+    fi
+  fi
+
   # Switch to a temporary directory so the extracted file does not clobber anything
   # some special handling here to support macos: http://unix.stackexchange.com/a/84980/210181
   tmp_dir=`mktemp -d -p . 2>/dev/null || TMPDIR=$(pwd) mktemp -d -t 'unrarall'`
@@ -856,9 +901,9 @@ for file in $(find_wrapper "$DIR" -depth -iregex '.*\.(rar|001)$'); do
   fi
 
   # Check if any recursive extraction is needed
-  if [ "${UNRARALL_DEPTH}" -gt 0 ] && [[ -n `find_wrapper . -depth -iregex '.*\.(rar|001)$'` ]]; then
+  if [ "${DEPTH}" -gt 0 ] && [[ -n `find_wrapper . -depth -iregex '.*\.(rar|001)$'` ]]; then
     [ $VERBOSE -eq 1 ] && message ok "Detected rar archives inside of \"$file\", recursively extracting"
-    let NEW_DEPTH=UNRARALL_DEPTH-1
+    let NEW_DEPTH=DEPTH-1
     eval $UNRARALL_CMD --depth $NEW_DEPTH ${tmp_dir}
   fi
 

--- a/unrarall
+++ b/unrarall
@@ -92,7 +92,7 @@ OPTIONS
 --depth              Maximum depth that nested rar files will be extracted. By
                      default, is a depth of 8.
 --skip-if-exists     Skip extraction of archive if all files already exists.
-                     Note: files are only checked by name, not by matching contents
+                     Note: files are only checked by name, not by contents!
 --password-file      Specify path to password file.
                      Default \"${UNRARALL_PASSWORD_FILE}\".
 --backend            Force particular backend (unrar, rar, or 7z)
@@ -889,6 +889,18 @@ for file in $(find_wrapper "$DIR" -depth -iregex '.*\.(rar|001)$'); do
       fi
     fi
   fi
+
+  # Check if any recursive extraction is needed
+  if [ "$SUCCESS" -eq 0 ] && [ "${DEPTH}" -gt 0 ] && [[ -n `find_wrapper . -depth -iregex '.*\.(rar|001)$'` ]]; then
+    [ $VERBOSE -eq 1 ] && message ok "Detected rar archives inside of \"$file\", recursively extracting"
+    let NEW_DEPTH=DEPTH-1
+    eval $UNRARALL_CMD --depth $NEW_DEPTH ${tmp_dir}
+    if [ $? -ne 0 ]; then
+      message error "Failed to recursively extract \"${filenameAbsolute}\""
+      SUCCESS=1
+    fi
+  fi
+
   # if fail remove from count
   if [ "$SUCCESS" -eq 0 ] && [ "$FORCE" -eq 0 ] ; then
     message ok "ok";
@@ -898,13 +910,6 @@ for file in $(find_wrapper "$DIR" -depth -iregex '.*\.(rar|001)$'); do
     let COUNT=COUNT-1
     let FAIL_COUNT=FAIL_COUNT+1
     [ "$FORCE" -eq 0 ] && message error "failed" || message error "failed (forced)"
-  fi
-
-  # Check if any recursive extraction is needed
-  if [ "${DEPTH}" -gt 0 ] && [[ -n `find_wrapper . -depth -iregex '.*\.(rar|001)$'` ]]; then
-    [ $VERBOSE -eq 1 ] && message ok "Detected rar archives inside of \"$file\", recursively extracting"
-    let NEW_DEPTH=DEPTH-1
-    eval $UNRARALL_CMD --depth $NEW_DEPTH ${tmp_dir}
   fi
 
   # Save the files extracted

--- a/unrarall
+++ b/unrarall
@@ -771,7 +771,8 @@ for file in $(find_wrapper "$DIR" -depth -iregex '.*\.(rar|001)$'); do
   filenameAbsolute="$(pwd)/${filename}"
 
   # Switch to a temporary directory so the extracted file does not clobber anything
-  tmp_dir=`mktemp -d -p . 2>/dev/null`
+  # some special handling here to support macos: http://unix.stackexchange.com/a/84980/210181
+  tmp_dir=`mktemp -d -p . 2>/dev/null || TMPDIR=$(pwd) mktemp -d -t 'unrarall'`
   if [ $? -ne 0 ] || [ -z ${tmp_dir} ] || [ ! -d "${tmp_dir}" ]; then
     message error "Failed to create a temporary directory to handle extraction"
     exit 1


### PR DESCRIPTION
This PR is intended to implement the features outlined in #37, and when complete should obsolete my previous PR, #30. ~I'm leaving #30 open for now as it is a working implementation, while this is presently a work-in-progress.~ *Not a WIP anymore.

TODO:
- [x] Extract the contents of a rar into a temporary directory
- [x] Prevent the contents of a rar from being clobbered when a file with the same name already exists
- [x] Handle recursive extraction of rar archives inside of rar archives, for a certain maximum depth
- [x] Detect and skip already extracted contents of a rar archive
- [x] Write unit tests to cover all of the new features and additional flags

The files not being clobbered doesn't happen exactly the way outlined in #37, it uses the `mv -b` featureset, which when the file `foo` exists and `mv -b bar foo` is called, will move `bar` to location `foo~` instead. The rename suffix of the backup file can be overridden by environment variables, see `man mv` for details. This approach seems significantly more maintainable than trying to generate a unique suffix and move the file to that location ourselves, when `mv` can handle it for us. The downside is it's not possible to issue a warning for the renamed file because `mv` doesn't tell us about it. `mv -v` verbose output shows the backup rename but parsing it seems like a significant burden for such a tiny gain. Thoughts @delcypher, others?

I'll hopefully tackle the remaining major features in the next few days.
