### PR TITLE
unrarall: hide unnecessary mv output in alpine

### DIFF
--- a/unrarall
+++ b/unrarall
@@ -42,7 +42,7 @@ declare -x UNRARALL_OUTPUT_DIR=""
 declare -ix DEPTH=4
 declare -ix SKIP_IF_EXISTS=0
 declare -ix MV_BACKUP=0 # 0 -> we can use mv -b, 1 -> resort to shenanigans to not clobber when moving
-`mv --help | grep  "\-\-backup" 2>&1 >/dev/null`
+`mv --help 2>&1 | grep  "\-\-backup" 2>&1 >/dev/null`
 MV_BACKUP=$?
 
 function usage()


### PR DESCRIPTION
Some versions of `mv` print help output to stderr rather than stdout. This breaks the check to see if `mv` supports `--backup` and also prints help text to the console. If we pipe stderr to stdin that should make unrarall more platform independent.

You can check the different behavior of `mv` with:
```
docker run --rm -it ubuntu bash -c 'mv --help 1>/dev/null' # doesn't print any output
docker run --rm -it alpine ash -c 'mv --help 1>/dev/null' # prints output
```